### PR TITLE
Adding new commands to show type inference

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -6,8 +6,10 @@ augroup agda
     " Normal mode bindings.
     autocmd Filetype agda nnoremap <buffer> <leader>l :write<cr>:AgdaLoad<cr>
     autocmd Filetype agda nnoremap <buffer> <leader>n :AgdaCompute<cr>
+    autocmd Filetype agda nnoremap <buffer> <leader>t :AgdaInferType<cr>
 
     " Visual mode bindings.
-    autocmd Filetype agda vnoremap <buffer> <leader>l :write<cr>:AgdaLoad<cr>
+    "autocmd Filetype agda vnoremap <buffer> <leader>l :write<cr>:AgdaLoad<cr>
     autocmd Filetype agda vnoremap <buffer> <leader>n :AgdaComputeSelection<cr>
+    autocmd Filetype agda vnoremap <buffer> <leader>t :AgdaInferTypeSelection<cr>
 augroup END


### PR DESCRIPTION
Adding two new commands:

- `AgdaInferType`: Works as `AgdaCompute` but returns the type of the
  expression not its value
- `AgdaInferTypeSelection`: Selection version of `AgdaInferType`

and, adding two new mappings `<leader>t` (non-selection and selection
version).